### PR TITLE
Add GPIO relay support

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,8 @@ pip install zorg zorg-gpio
 
 * [LED](led.md)
 * [Servo](servo.md)
-* [Analog sensor](light_sensor.md)
+* [Relay](relay.md)
+* [Analog sensor](analog_sensor.md)
 * [Light sensor](light_sensor.md)
 * [Temperature sensor](temperature_sensor.md)
 

--- a/docs/relay.md
+++ b/docs/relay.md
@@ -1,0 +1,25 @@
+# Relay
+
+## `set_state`
+
+_Parameters:_ `state` Should be an integer value of 1 or 0.
+
+Sets the state of the relay on (open) or off (closed).
+
+## `is_on`
+
+Returns true if the relay is on, false if the relay is off.
+
+## `turn_on`
+
+Turns the relay on.
+
+## `turn_off`
+
+Turns the relay off.
+
+## `toggle`
+
+Toggles the state of the relay. (If the relay is on, then it will be turned off,
+if it is off, then it will be turned on.)
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,5 +5,6 @@ pages:
 - Drivers:
   - LED: led.md
   - Servo: servo.md
+  - Relay: relay.md
   - Temperature sensor: temperature_sensor.md
 theme: readthedocs

--- a/tests/smoke_tests/test_commands.py
+++ b/tests/smoke_tests/test_commands.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 from zorg_gpio import AnalogSensor
 from zorg_gpio import TemperatureSensor
 from zorg_gpio import Servo
+from zorg_gpio import Relay
 from zorg_gpio import Led
 
 
@@ -49,6 +50,19 @@ class ServoSmokeTests(SmokeTestCase):
 
         for command in servo.commands:
             self.assertIn(command, dir(servo))
+
+
+class RelaySmokeTests(SmokeTestCase):
+
+    def test_command_method_exists(self):
+        """
+        Check that each command listed has a corresponding
+        method on the driver class.
+        """
+        relay = Relay(self.options, self.connection)
+
+        for command in relay.commands:
+            self.assertIn(command, dir(relay))
 
 
 class TemperatureSmokeTests(SmokeTestCase):

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -1,5 +1,6 @@
 from zorg_gpio.led import Led
 from zorg_gpio.servo import Servo
+from zorg_gpio.relay import Relay
 from .mock_device import MockDriver
 from unittest import TestCase
 
@@ -47,3 +48,35 @@ class TestServo(TestCase):
         def test_get_angle(self):
             self.servo.set_angle(150)
             self.assertEqual(self.servo.get_angle(), 150)
+
+
+class TestRelay(TestCase):
+
+    def setUp(self):
+        self.relay = Relay({}, MockDriver())
+
+    def test_set_state_on(self):
+        self.relay.set_state(1)
+        self.assertEqual(self.relay.is_on(), True)
+
+    def test_set_state_off(self):
+        self.relay.set_state(0)
+        self.assertEqual(self.relay.is_on(), False)
+
+    def test_turn_on(self):
+        self.relay.turn_on()
+        self.assertEqual(self.relay.is_on(), True)
+
+    def test_turn_off(self):
+        self.relay.turn_off()
+        self.assertEqual(self.relay.is_on(), False)
+
+    def test_toggle(self):
+        self.relay.toggle()
+        first_toggle = self.relay.is_on()
+
+        self.relay.toggle()
+        second_toggle = self.relay.is_on()
+
+        self.assertTrue(first_toggle != second_toggle)
+

--- a/zorg_gpio/__init__.py
+++ b/zorg_gpio/__init__.py
@@ -1,3 +1,4 @@
+from .relay import Relay
 from .servo import Servo
 from .led import Led
 from .light_sensor import LightSensor

--- a/zorg_gpio/relay.py
+++ b/zorg_gpio/relay.py
@@ -1,0 +1,42 @@
+from zorg.driver import Driver
+
+
+class Relay(Driver):
+
+    def __init__(self, options, connection):
+        super(Relay, self).__init__(options, connection)
+
+        self.current_state = False
+
+        self.commands = [
+            "set_state",
+            "is_on",
+            "turn_on",
+            "turn_off",
+            "toggle",
+        ]
+
+    def set_state(self, state):
+        """
+        State should be a 1 or a 0.
+        """
+        self.current_state = (state == 1)
+        self.connection.digital_write(self.pin, state)
+
+    def is_on(self):
+        return self.current_state
+
+    def turn_on(self):
+        self.current_state = True
+        self.connection.digital_write(self.pin, 1)
+
+    def turn_off(self):
+        self.current_state = False
+        self.connection.digital_write(self.pin, 0)
+
+    def toggle(self):
+        if self.is_on():
+            self.turn_off()
+        else:
+            self.turn_on()
+


### PR DESCRIPTION
Based on the [cylon relay.js](https://github.com/hybridgroup/cylon-gpio/blob/master/lib/relay.js) module, it looks like relays have pretty much the same API as LEDs. With that in mind here is a relay driver that should work correctly for any general relay.

- [x] Driver
- [x] Tests
- [x] Documentation

For #1